### PR TITLE
Create snapshots of targets for each version-iteration

### DIFF
--- a/R/figures/health_labor_revised_figs.R
+++ b/R/figures/health_labor_revised_figs.R
@@ -603,7 +603,7 @@ plot_npv_labor_oilpx <- function(
   } else if (variant == "bartik") {
     return(forgone_wages_all_oil_px_fig_2020ppx_bc)
   } else {
-    return(forgone_wages_all_oil_px_fig)  # base variant (changing prices)
+    return(forgone_wages_all_oil_px_fig) # base variant (changing prices)
   }
 }
 
@@ -977,9 +977,9 @@ plot_npv_health_labor <- function(
     folder_path = NULL,
     filename = "state_npv_fig_inputs_health.csv",
     save_path = save_path,
-    file_type = "table",
-    figure_number = NULL,
-    extra_subfolder = "health"
+    file_type = "figure",
+    figure_number = "figure-3",
+    extra_subfolder = NULL
   )
 
   ## prepare labor ----------------------
@@ -9605,11 +9605,15 @@ plot_hl_levels_pc <- function(
 
   ## calculate per capita
   plot_df_long[, value := value / pop_2020]
-  
+
   ## udpate labor segment title
-  plot_df_long[, seg_title := fifelse(seg_title == "Labor: forgone wages",
-                                      "Labor: forgone wages of directly employed workers",
-                                      seg_title)]
+  plot_df_long[,
+    seg_title := fifelse(
+      seg_title == "Labor: forgone wages",
+      "Labor: forgone wages of directly employed workers",
+      seg_title
+    )
+  ]
 
   ## save figure inputs
   simple_fwrite_repo(
@@ -13133,7 +13137,7 @@ fig4_hl_pmil <- function(
       filter(
         !scenario %in% remove_scen,
         product_scenario == "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised",
         title %in% fig_title_vec,
         demo_cat == "Race"
@@ -13182,7 +13186,7 @@ fig4_hl_pmil <- function(
       filter(
         !scenario %in% remove_scen,
         product_scenario != "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised",
         title %in% fig_title_vec,
         demo_cat == "Race"
@@ -13291,7 +13295,7 @@ fig4_hl_pmil <- function(
         !scenario %in% remove_scen,
         demo_cat == "DAC",
         product_scenario == "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised",
       ),
     aes(x = year, y = gap_emp_pmil, lty = title)
@@ -13334,7 +13338,7 @@ fig4_hl_pmil <- function(
         !scenario %in% remove_scen,
         demo_cat == "DAC",
         product_scenario != "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised"
       ),
     aes(x = year, y = gap_emp_pmil, lty = title)
@@ -13429,7 +13433,7 @@ fig4_hl_pmil <- function(
       filter(
         !scenario %in% remove_scen,
         product_scenario == "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised",
         demo_cat == "Poverty"
       ) %>%
@@ -13478,7 +13482,7 @@ fig4_hl_pmil <- function(
       filter(
         !scenario %in% remove_scen,
         product_scenario != "changing prices",
-        ## with re-employment 
+        ## with re-employment
         employment_scen == "sum_demo_emp_revised",
         demo_cat == "Poverty"
       ) %>%

--- a/_targets.R
+++ b/_targets.R
@@ -115,6 +115,12 @@ list(
     command = create_save_folders_repo(save_path, iteration)
   ),
 
+  # create targets snapshot for this version-iteration
+  tar_target(
+    name = targets_snapshot,
+    command = create_targets_snapshot(save_path, version, iteration)
+  ),
+
   # energy intensities
   tar_target(name = ei_crude, command = 5.698), # mmbtu/bbl; source: https://www.eia.gov/totalenergy/data/monthly/pdf/sec12_3.pdf
   tar_target(name = ei_gasoline, command = 5.052), # mmbtu/bbl; source: https://www.eia.gov/totalenergy/data/monthly/pdf/sec12_4.pdf

--- a/_targets.R
+++ b/_targets.R
@@ -68,9 +68,19 @@ list(
     command = list_paths[user]
   ),
 
+  # module settings
+  tar_target(name = ref_threshold, command = 0.8),
+  tar_target(name = ren_threshold, command = 0.9),
+  tar_target(name = pred_years, command = 2020:2045),
+  tar_target(name = drop_in_perc, command = 1),
+  tar_target(name = kern_perc, command = 0.9375),
+  # tar_target(name = a, command = 4),
+  # tar_target(name = ccs_capture_rate, command = 0.474),
+  tar_target(name = refinery_level_ghg, command = FALSE),
+
   # list save paths
-  tar_target(name = version, command = "rev-submission"),
-  tar_target(name = iteration, "cuf=0.6"),
+  tar_target(name = version, command = "missing-labor-outputs"),
+  tar_target(name = iteration, command = paste0("cuf=", ref_threshold)),
 
   # Set run type and stop if unknown run type
   tar_target(
@@ -104,16 +114,6 @@ list(
     name = save_folders,
     command = create_save_folders_repo(save_path, iteration)
   ),
-
-  # module settings
-  tar_target(name = ref_threshold, command = 0.8),
-  tar_target(name = ren_threshold, command = 0.9),
-  tar_target(name = pred_years, command = 2020:2045),
-  tar_target(name = drop_in_perc, command = 1),
-  tar_target(name = kern_perc, command = 0.9375),
-  # tar_target(name = a, command = 4),
-  # tar_target(name = ccs_capture_rate, command = 0.474),
-  tar_target(name = refinery_level_ghg, command = FALSE),
 
   # energy intensities
   tar_target(name = ei_crude, command = 5.698), # mmbtu/bbl; source: https://www.eia.gov/totalenergy/data/monthly/pdf/sec12_3.pdf

--- a/extras/output_structure.csv
+++ b/extras/output_structure.csv
@@ -122,7 +122,7 @@ state_levels_pmil_fig_inputs.csv,tables/health,NO
 state_npv_fig_inputs_health_annual_vsl.csv,tables/health,NO
 state_npv_fig_inputs_health_non_age_vsl.csv,tables/health,NO
 state_npv_fig_inputs_health_ref.csv,tables/health,NO
-state_npv_fig_inputs_health.csv,tables/health,NO
+state_npv_fig_inputs_health.csv,results/figures/figure-3,YES
 labor_county_outputs.csv,tables/labor,YES
 labor_high_low_annual_outputs.csv,tables/labor,YES
 state_labor_levels_fig_gaps_inputs.csv,tables/labor,NO


### PR DESCRIPTION
The changes made with this PR are:
- For each version-iteration, two snapshot files are created: one with a summary of the parameters and settings in `_targets.R` (called `targets_snapshot_summary.R`) and one that is just the complete `_targets.R` file at the time when the version-iteration was run (called `targets_snapshot_full.R`). Both of these are saved in `/outputs/version/iteration/`'
- `iteration` is now dependent on `ref_threshold` instead of being manually named
- The save location of `state_npv_fig_inputs_health.csv` has been changed to /figures/figure-3

Note that this PR only includes codebase changes, and I am not including the changes to the actual outputs in this.