### PR TITLE
Change how figure 3 outputs are saved

### DIFF
--- a/R/figures/health_labor_revised_figs.R
+++ b/R/figures/health_labor_revised_figs.R
@@ -971,16 +971,7 @@ plot_npv_health_labor <- function(
   ]
   plot_df_health[, scenario := str_replace(scenario, "historic", "historical")]
 
-  ## save figure inputs
-  simple_fwrite_repo(
-    plot_df_health,
-    folder_path = NULL,
-    filename = "state_npv_fig_inputs_health.csv",
-    save_path = save_path,
-    file_type = "figure",
-    figure_number = "figure-3",
-    extra_subfolder = NULL
-  )
+  ## Figure inputs will be saved by targets pipeline
 
   ## prepare labor ----------------------
   plot_df_labor <- plot_df_labor %>%
@@ -1061,16 +1052,7 @@ plot_npv_health_labor <- function(
   ]
   plot_df_labor[, scenario := str_replace(scenario, "historic", "historical")]
 
-  ## save figure inputs
-  simple_fwrite_repo(
-    plot_df_labor,
-    folder_path = NULL,
-    filename = "state_npv_fig_inputs_labor.csv",
-    save_path = save_path,
-    file_type = "table",
-    figure_number = NULL,
-    extra_subfolder = "labor"
-  )
+  ## Figure inputs will be saved by targets pipeline
 
   ## scenarios for filtering
   remove_scen <- c("LC1 historical production", "BAU historical production")
@@ -1733,7 +1715,12 @@ plot_npv_health_labor <- function(
   #   # rel_widths = c(1, 1),
   # )
 
-  return(fig3_plot_grid_ab)
+  # Return both plot and processed data
+  return(list(
+    plot = fig3_plot_grid_ab,
+    plot_data_health = plot_df_health,
+    plot_data_labor = plot_df_labor
+  ))
 }
 
 

--- a/_targets.R
+++ b/_targets.R
@@ -80,7 +80,7 @@ list(
   tar_target(name = ref_threshold, command = 0.6),
 
   # list save paths (UPDATE VERSION AS NEEDED)
-  tar_target(name = version, command = "rev-submission"),
+  tar_target(name = version, command = "fig3-edit"),
   tar_target(
     name = iteration,
     command = paste0("cuf=", ref_threshold, "_beta-scenario=", beta_scenario)
@@ -1592,7 +1592,7 @@ list(
     )
   ),
   tar_target(
-    name = npv_plot,
+    name = npv_plot_result,
     command = plot_npv_health_labor(
       main_path,
       save_path,
@@ -1601,6 +1601,11 @@ list(
       dt_ghg_2019,
       annual_all_impacts_labor
     )
+  ),
+
+  tar_target(
+    name = npv_plot,
+    command = npv_plot_result$plot
   ),
   tar_target(
     name = npv_plot_ref,
@@ -2406,7 +2411,7 @@ list(
     command = simple_ggsave_repo(
       fig_demand_ghg,
       NULL,
-      "combined_its_and_production*",
+      "combined_its_and_production",
       width = 25,
       save_path = save_path,
       file_type = "figure",
@@ -2421,7 +2426,7 @@ list(
     command = simple_ggsave_repo(
       npv_plot,
       NULL,
-      "state_npv_fig_2020_ppx_bartik*",
+      "state_npv_fig_2020_ppx_bartik",
       width = 10,
       save_path = save_path,
       file_type = "figure",
@@ -2937,9 +2942,22 @@ list(
 
   # ---- Missing CSV input file targets from output_structure.csv ----
   tar_target(
+    name = save_npv_fig_inputs_health,
+    command = simple_fwrite_repo(
+      data = npv_plot_result$plot_data_health, # Processed health data from plot function
+      folder_path = NULL,
+      filename = "state_npv_fig_inputs_health.csv",
+      save_path = save_path,
+      file_type = "figure",
+      figure_number = "figure-3"
+    ),
+    format = "file"
+  ),
+
+  tar_target(
     name = save_npv_fig_inputs_labor,
     command = simple_fwrite_repo(
-      data = annual_all_impacts_labor, # Labor data used for NPV calculations
+      data = npv_plot_result$plot_data_labor, # Processed labor data from plot function
       folder_path = NULL,
       filename = "state_npv_fig_inputs_labor.csv",
       save_path = save_path,


### PR DESCRIPTION
This PR changes how the outputs related to figure 3 are saved.

The issue is that the target/output that was being saved for figure 3 (target `annual_all_impacts_labor` -> `state_npv_fig_inputs_labor.csv`) is an input that gets fed to the function that eventually makes Figure 3. But `annual_all_impacts_labor` does not contain the data processing that happens between reading it into the target and before it is ready for plotting.

Thus, this output has been replaced by outputs that were used for plotting.

The following changes were made to the `plot_npv_health_labor()` function in `health_labor_revised_figs.R`:
- Changed return value from just the plot object to a list containing:
  - plot: the final plot object (fig3_plot_grid_ab)
  - plot_data_health: the processed health data (plot_df_health)
  - plot_data_labor: the processed labor data (plot_df_labor)
- Removed internal data saving calls since the targets pipeline now handles this

The following changes were made to `_targets.R`:
 - Created new `npv_plot_result` target that captures the full list returned by the function
 - Modified `npv_plot` target to extract just the plot component (`npv_plot_result$plot`)
 - Updated `save_npv_fig_inputs_labor` to save the processed labor data (`npv_plot_result$plot_data_labor`) instead of `annual_all_impacts_labor`
 - Added new `save_npv_fig_inputs_health` target to save the processed health data (`npv_plot_result$plot_data_health`)